### PR TITLE
Fixed link, and corrected selector type in css style sheet

### DIFF
--- a/Develop/assets/css/style.css
+++ b/Develop/assets/css/style.css
@@ -8,23 +8,27 @@ body {
     background-color: #d9dcd6;
 }
 
-.header {
+/*.header*/
+header {
     padding: 20px;
     font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
     background-color: #2a607c;
     color: #ffffff;
 }
 
-.header h1 {
+/*.header h1*/
+header h1 {
     display: inline-block;
     font-size: 48px;
 }
 
-.header h1 .seo {
+/*.header h1 .seo*/
+header h1 .seo {
     color: #d9dcd6;
 }
 
-.header div {
+/*.header div*/
+header nav {
     padding-top: 15px;
     margin-right: 20px;
     float: right;
@@ -32,11 +36,13 @@ body {
     font-size: 20px;
 }
 
-.header div ul {
+/*.header div ul*/
+header nav ul {
     list-style-type: none;
 }
 
-.header div ul li {
+/*.header div ul li*/
+header nav ul li {
     display: inline-block;
     margin-left: 25px;
 }
@@ -188,13 +194,15 @@ p {
     font-size: 36px;
 }
 
-.footer {
+/*changed selector from class (.footer) to tag (footer)*/
+footer {
     padding: 30px;
     clear: both;
     font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
     text-align: center;
 }
 
-.footer h2 {
+/*changed selector from class (.footer) to tag (footer)*/
+footer h2 {
     font-size: 20px;
 }

--- a/Develop/index.html
+++ b/Develop/index.html
@@ -27,7 +27,8 @@
     </header>    <!-- Oriinal code: </div> -->
     <img class="hero">  <!-- <div class="hero"></div> -->
     <main class="content">   <!-- <div class="content"> -->
-        <section class="search-engine-optimization">   <!-- <div class="search-engine-optimization"> -->
+        <!--id="search-engine-optimization" was missing from the original code. It was added to make the link work-->
+        <section id="search-engine-optimization" class="search-engine-optimization">   <!-- <div class="search-engine-optimization"> -->
             <figure> <!--Added figure element -->
                 <img src="./assets/images/search-engine-optimization.jpg" class="float-left" alt="multiple objects on a table"/>
             </figure>


### PR DESCRIPTION
1. One broken link was found and corrected. Search Engine Optimization link was missing an id selector. If you click on Search Engine Optimization, it will now direct you to that section of the project
2. Multiple selectors in the CSS Style Sheet were corrected. Semantic HTML was added to the html sheet, but were not corrected in the CSS sheet. This merge will corret that. Selectors correcter were: header, nav, and footer
