### PR TITLE
Corrected the footer heading

### DIFF
--- a/Develop/assets/css/style.css
+++ b/Develop/assets/css/style.css
@@ -202,7 +202,7 @@ footer {
     text-align: center;
 }
 
-/*changed selector from class (.footer) to tag (footer)*/
-footer h2 {
+/*.footet h2 {
     font-size: 20px;
-}
+    }*/
+

--- a/Develop/index.html
+++ b/Develop/index.html
@@ -88,7 +88,8 @@
         </section>   <!-- </div> -->
     </aside> <!-- </div> -->
     <footer class="footer">   <!-- <div class="footer"> -->
-        <h2>Made with ❤️️ by Horiseon</h2>
+        <!--<h2></h2>-->
+        <h3>Made with ❤️️ by Horiseon</h3>
         <p>
             &copy; 2019 Horiseon Social Solution Services, Inc.
         </p>


### PR DESCRIPTION
The footer previously had an h2 element. This was replaced with an h3 element, so that the headings can be in sequencial order. This will also reduce code. The footer h2 code in the CSS style sheet was no longer needed. Therefor it was elimiated. 