### PR TITLE
fixed-README-bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Usage
 
-![alt text](Develop/assets/images/screenshot.png)
+![alt text](assets/images/screenshot.png)
 
 
 


### PR DESCRIPTION
Corrected path to image 
The screenhot image was not longer working because the Develop directory was deleted. New path was added